### PR TITLE
Add inference validator output

### DIFF
--- a/intro_inference_validation.csv
+++ b/intro_inference_validation.csv
@@ -1,0 +1,7 @@
+question_id,html_answer,calculated_answer,match
+4,c,c,True
+5,b,b,True
+6,b,b,True
+7,a,a,True
+9,c,c,True
+19,c,c,True

--- a/scripts/inference_utils.py
+++ b/scripts/inference_utils.py
@@ -1,0 +1,46 @@
+from math import sqrt, ceil
+from statistics import NormalDist
+
+_norm = NormalDist()
+
+
+def se_mean(sample_sd: float, n: int) -> float:
+    """Return standard error of the sample mean."""
+    return sample_sd / sqrt(n)
+
+
+def prob_mean_exceeds(threshold: float, mu: float, sigma: float, n: int) -> float:
+    """Probability sample mean exceeds threshold using CLT."""
+    se = sigma / sqrt(n)
+    z = (threshold - mu) / se
+    return 1 - _norm.cdf(z)
+
+
+def se_proportion(p_hat: float, n: int) -> float:
+    """Standard error of a sample proportion."""
+    return sqrt(p_hat * (1 - p_hat) / n)
+
+
+def confidence_interval_proportion(p_hat: float, n: int, alpha: float = 0.05):
+    """Return lower and upper bounds of CI for proportion."""
+    z = _norm.inv_cdf(1 - alpha / 2)
+    se = se_proportion(p_hat, n)
+    moe = z * se
+    return p_hat - moe, p_hat + moe
+
+
+def z_test_proportion(p_hat: float, n: int, p0: float) -> float:
+    """Z test statistic for single proportion."""
+    se = sqrt(p0 * (1 - p0) / n)
+    return (p_hat - p0) / se
+
+
+def sample_size_for_moe(moe: float, p: float = 0.5, alpha: float = 0.05) -> int:
+    """Sample size needed for given margin of error for proportion."""
+    z = _norm.inv_cdf(1 - alpha / 2)
+    return ceil(z**2 * p * (1 - p) / moe**2)
+
+
+def z_critical(alpha: float) -> float:
+    """Two-sided z critical value for significance level alpha."""
+    return _norm.inv_cdf(1 - alpha / 2)

--- a/scripts/validate_intro_inference.py
+++ b/scripts/validate_intro_inference.py
@@ -1,0 +1,68 @@
+import csv
+import re
+from pathlib import Path
+
+from inference_utils import (
+    se_mean,
+    prob_mean_exceeds,
+    confidence_interval_proportion,
+    z_test_proportion,
+    sample_size_for_moe,
+    z_critical,
+)
+
+HTML_FILE = Path('interactive-problem-sets/introduction-to-inference/index.html')
+OUTPUT_CSV = Path('intro_inference_validation.csv')
+
+
+def parse_correct_answers(html_text: str):
+    pattern = re.compile(r'{\s*id:\s*(\d+).*?correctAnswer:\s*"([a-d])"', re.S)
+    return {int(qid): ans for qid, ans in re.findall(pattern, html_text)}
+
+
+def main():
+    html_text = HTML_FILE.read_text()
+    answers = parse_correct_answers(html_text)
+
+    # Hard-coded calculations for numeric questions
+    calculated = {}
+
+    # Q4: SE of mean
+    se = se_mean(10, 100)
+    calculated[4] = 'c' if abs(se - 1) < 1e-6 else None
+
+    # Q5: Probability mean exceeds 52
+    prob = prob_mean_exceeds(52, 50, 10, 100)
+    calculated[5] = 'b' if abs(prob - 0.023) < 0.005 else None
+
+    # Q6: 95% CI for proportion
+    p_hat = 120 / 400
+    ci = confidence_interval_proportion(p_hat, 400)
+    if abs(ci[0] - 0.255) < 0.005 and abs(ci[1] - 0.345) < 0.005:
+        calculated[6] = 'b'
+    else:
+        calculated[6] = None
+
+    # Q7: Z test statistic for proportion
+    z = z_test_proportion(0.48, 1000, 0.5)
+    calculated[7] = 'a' if abs(z + 1.27) < 0.05 else None
+
+    # Q9: required sample size for MOE 0.05
+    n_required = sample_size_for_moe(0.05, p=0.5)
+    calculated[9] = 'c' if n_required == 385 else None
+
+    # Q19: Z critical value for 99% CI
+    zcrit = z_critical(0.01)
+    calculated[19] = 'c' if abs(zcrit - 2.576) < 0.01 else None
+
+    with OUTPUT_CSV.open('w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(['question_id', 'html_answer', 'calculated_answer', 'match'])
+        for qid in sorted(calculated):
+            html_ans = answers.get(qid)
+            calc_ans = calculated[qid]
+            writer.writerow([qid, html_ans, calc_ans, html_ans == calc_ans])
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/validation_protocol.md
+++ b/scripts/validation_protocol.md
@@ -1,0 +1,28 @@
+# Introduction to Inference Problem Set Validation Protocol
+
+This document describes the procedure used to verify that the hard-coded answers in
+`interactive-problem-sets/introduction-to-inference/index.html` match the results of
+independent calculations.
+
+## Steps
+
+1. **Utility Module** – `scripts/inference_utils.py`
+   - Provides helper functions for standard errors, confidence intervals,
+     hypothesis tests and required sample sizes derived from Lecture Slides 7 and 8.
+   - Functions rely only on Python's standard library (`math` and `statistics`).
+
+2. **Validation Script** – `scripts/validate_intro_inference.py`
+   - Parses the HTML file for each question's `id` and `correctAnswer` letter.
+   - Recreates all numeric problems from the HTML with hard-coded parameters and
+     computes answers using functions from `inference_utils`.
+   - Writes `intro_inference_validation.csv` summarising the HTML answer,
+     the calculated answer and whether they match for each numeric question.
+
+3. **Running Validation**
+
+```bash
+python3 scripts/validate_intro_inference.py
+```
+
+The script produces `intro_inference_validation.csv` in the repository root.
+Any discrepancy will appear with `False` in the `match` column.


### PR DESCRIPTION
## Summary
- reuse inference helper utilities to check HTML answers
- run the validator and save the CSV output

## Testing
- `python3 scripts/validate_intro_inference.py && cat intro_inference_validation.csv`

------
https://chatgpt.com/codex/tasks/task_e_6857411bb4248332a7fddca4998b2008