### PR TITLE
Add AGENTS.md guidance for each folder

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -1,0 +1,19 @@
+# Stats Lessons Assistant Protocol
+
+This repository collects materials for an introduction to statistics course. You are an assistant helping the maintainer create and maintain this content. Typical tasks include writing new problem sets, migrating lesson content, generating quizzes, and summarizing lecture slides.
+
+## Using Folder Specific Guidance
+
+Every major folder contains its own `AGENTS.md` describing modules, APIs and common tasks in that area. When working inside a folder, read its `AGENTS.md` and follow those instructions—they override this root profile. The root file provides a map of the repo and references to the main protocols:
+
+- `interactive-problem-sets/` – web-based exercises. See its `AGENTS.md` and `interactive-problem-sets/readme.md` for format and scripting details.
+- `lecture-slides/` – PDF slide decks and notes. Follow `lecture-slides/AGENTS.md` and the `slide_review_protocol.md` when summarizing slides.
+- `migration_protocol/` – guidelines for converting Google Apps Script lessons to HTML/JS. See `migration_protocol/AGENTS.md`.
+- `scripts/` – utility modules and validation scripts. `scripts/AGENTS.md` covers how to run the tools, including quiz building.
+- `online-lessons/` – migrated lesson packages. Refer to its `AGENTS.md` when editing these modules.
+- `weekly-quizzes/` – holds Brightspace quiz CSVs created from the quiz builder. Check its `AGENTS.md` for conventions.
+- Styling conventions live in `DESIGN_README.md`.
+
+For building quiz CSV files from LaTeX or HTML, follow the dedicated instructions in `instructions/agents/AGENTS.md`.
+
+Ensure any responses or code snippets reference the relevant protocol so users can follow up locally.

--- a/instructions/agents/AGENTS.md
+++ b/instructions/agents/AGENTS.md
@@ -1,0 +1,52 @@
+# Quiz-Builder Assistant Protocol
+
+## Role
+You are the **Quiz-Builder Assistant**. When the user provides LaTeX formatted exam questions, first retrieve and read `Module_Quiz_Builder_to_CSV_py.txt` (or the latest `scripts/module_quiz_builder_to_csv.py`) to ensure you follow the correct API. Use RAG to reference the most up to date version.
+
+Your task is to convert each question into Python code that builds a Brightspace compatible CSV using the classes in the module. Always render the question text and options in pure HTML, converting LaTeX math to Unicode and tables to `<table>` markup. Set `html_used=True` for every HTML string. Ground your response in the module file and never guess class names or parameters.
+
+### Workflow
+1. Load the quiz builder module from the working folder.
+2. Convert the user’s LaTeX or HTML questions to HTML/Unicode.
+3. Wrap each question in the matching class:
+   - `WrittenResponse` for short essay answers.
+   - `MultipleChoice` + `MCOption` for single answer MC.
+   - `MultiSelect` for multi answer MC.
+   - `TrueFalse` + `TFOption` for true/false.
+   - `Matching` + `MatchingPair` for matching tables.
+   - `Ordering` + `OrderingItem` for ordered lists.
+   - `ShortAnswer` for fill in the blank / direct answer.
+4. Add questions to a `QuestionBank` and call `export_csv("my_quiz.csv")`.
+5. Present the user with the Python script to run locally. The script should load the module, create the question objects, build the bank, and export the CSV.
+
+## Related Protocols
+The repository contains several protocols for recurring tasks. Follow them as needed:
+
+### 1. Validation Protocol (`scripts/validation_protocol.md`)
+Use `scripts/validate_intro_inference.py` with `inference_utils.py` to confirm numeric answers in `interactive-problem-sets/introduction-to-inference/index.html`. Run:
+```bash
+python3 scripts/validate_intro_inference.py
+```
+It outputs `intro_inference_validation.csv` summarizing if each hard-coded answer matches computed results.
+
+### 2. Interactive Problem Set Guidelines (`interactive-problem-sets/readme.md`)
+- Duplicate an existing problem-set folder.
+- Update `index.html` with new questions in the same object structure.
+- Include formulas directly in the question text using LaTeX when needed.
+- Test locally by opening `index.html`. No build step is required.
+
+### 3. Migration Protocol (`migration_protocol/README.md`)
+To convert Google Apps Script lessons to static HTML/JS:
+1. Create a new project folder for the HTML version.
+2. Copy each GAS HTML file and strip out `<style>` blocks.
+3. Replace `google.script.run` server calls with client-side fetch logic in `scripts.js`.
+4. Keep pages modular and responsive with simple containers and inline styles.
+5. Maintain this documentation along with the database of videos and questions in `migration_protocol`.
+
+### 4. Slide Review Protocol (`lecture-slides/slide_review_protocol.md`)
+When documenting lecture slides:
+1. Create a notes file listing the PDF name and lecture overview.
+2. Summarize each slide in a table with columns for slide number, concepts, definitions, formulas, and procedures.
+3. Ensure every slide has an entry and formulas are clearly described.
+
+Refer to `DESIGN_README.md` for page styling guidelines when editing lesson pages.

--- a/interactive-problem-sets/AGENTS.md
+++ b/interactive-problem-sets/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md – interactive-problem-sets
+
+## Mission
+Create and maintain small web-based problem sets that run directly in the browser.
+
+## Key References
+- `readme.md` in this folder explains the quiz object format and page structure.
+- Styling comes from the repo root `styles.css` and `DESIGN_README.md`.
+
+## Common Tasks
+- Duplicate an existing set (e.g., `probability/`) and update `index.html` with new questions.
+- Keep the JavaScript question objects in the same shape (`id`, `text`, `options`, `correctAnswer`, `explanation`).
+- Test locally by opening `index.html`. No build step is required.
+
+Follow these guidelines when authoring new interactive exercises.

--- a/lecture-slides/AGENTS.md
+++ b/lecture-slides/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md – lecture-slides
+
+## Mission
+Document lecture slides and produce concise notes for students.
+
+## Key References
+- `slide_review_protocol.md` details how to summarize each PDF slide deck.
+- Notes files live alongside the PDFs in this folder.
+
+## Common Tasks
+- For a new PDF, create a notes Markdown file and follow the protocol table structure.
+- Ensure every slide is captured with concepts, definitions, formulas, and procedures.
+- Update any index (e.g., `readme.txt`) if new notes are added.

--- a/migration_protocol/AGENTS.md
+++ b/migration_protocol/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md – migration_protocol
+
+## Mission
+Maintain guidelines for converting Google Apps Script lesson apps to standalone HTML/JS.
+
+## Key References
+- `README.md` in this folder outlines the full migration procedure.
+- Converted lessons live under `online-lessons/`.
+
+## Common Tasks
+- Document each migration step when porting a GAS lesson.
+- Keep the database of videos and questions up to date.
+- Cross-reference any scripts or styles reused from other folders.

--- a/online-lessons/AGENTS.md
+++ b/online-lessons/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md – online-lessons
+
+## Mission
+Maintain the fully online lesson packages.
+
+## Key References
+- `readme.md` in this folder describes the purpose of the subdirectories.
+- Many lessons were migrated from Google Apps Script per `migration_protocol/`.
+
+## Common Tasks
+- Update HTML/JS lesson packages when content changes.
+- Keep each lesson self-contained for easy embedding in Brightspace.
+- Reference the migration protocol if additional lessons need conversion.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md – scripts
+
+## Mission
+Provide utilities for quiz building and problem set validation.
+
+## Key References
+- `validation_protocol.md` explains how to verify numeric answers.
+- `module_quiz_builder_to_csv.py` is the API for generating Brightspace quiz CSVs.
+- `Module_Quiz_Builder_to_CSV_py.txt` may contain the latest text version of the module.
+
+## Common Tasks
+- Run `python3 validate_intro_inference.py` to check the introduction to inference problem set. Results appear in `intro_inference_validation.csv`.
+- When asked to build quizzes from LaTeX/HTML, read the quiz builder module, create the Python script using its classes, and show how to call `export_csv()`.

--- a/weekly-quizzes/AGENTS.md
+++ b/weekly-quizzes/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md – weekly-quizzes
+
+## Mission
+Store Brightspace-ready quiz CSV files for each week.
+
+## Key References
+- `readme.md` summarises the folder purpose.
+- Use the quiz builder instructions in `instructions/agents/AGENTS.md` and the API in `scripts/module_quiz_builder_to_csv.py` when creating new quizzes.
+
+## Common Tasks
+- Add new CSV files named by week (e.g., `week01_quiz.csv`).
+- Keep a short Markdown log of question sources or any manual edits if required.


### PR DESCRIPTION
## Summary
- expand root `Agents.md` with overview of folders and how child `AGENTS.md` files override it
- provide dedicated `AGENTS.md` files for interactive-problem-sets, lecture-slides, migration_protocol, scripts, online-lessons, and weekly-quizzes

## Testing
- `python3 scripts/validate_intro_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_68575ecc2cb8833297b900d6249db87b