### PR TITLE
Update interactive problem set guidelines

### DIFF
--- a/interactive-problem-sets/AGENTS.md
+++ b/interactive-problem-sets/AGENTS.md
@@ -11,5 +11,7 @@ Create and maintain small web-based problem sets that run directly in the browse
 - Duplicate an existing set (e.g., `probability/`) and update `index.html` with new questions.
 - Keep the JavaScript question objects in the same shape (`id`, `text`, `options`, `correctAnswer`, `explanation`).
 - Test locally by opening `index.html`. No build step is required.
+- If a folder contains `question_index.csv`, update it whenever you add or remove questions so IDs stay in sync.
+- When modifying numeric problems (e.g., the Introduction to Inference set), run `python3 scripts/validate_intro_inference.py` to verify computed answers.
 
 Follow these guidelines when authoring new interactive exercises.


### PR DESCRIPTION
## Summary
- expand the guidance in `interactive-problem-sets/AGENTS.md`
  - mention updating `question_index.csv` when present
  - mention running `python3 scripts/validate_intro_inference.py` for numeric questions

## Testing
- `python3 scripts/validate_intro_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6857667f90f48332830b7cab64207ef4