### PR TITLE
Fix notes location instructions in slides AGENTS

### DIFF
--- a/lecture-slides/AGENTS.md
+++ b/lecture-slides/AGENTS.md
@@ -4,8 +4,8 @@
 Document lecture slides and produce concise notes for students.
 
 ## Key References
-- `slide_review_protocol.md` details how to summarize each PDF slide deck.
-- Notes files live alongside the PDFs in this folder.
+- `slide_review_protocol.md` details how to summarize each PDF slide deck and governs the Markdown note format.
+- Notes files live in the `notes/` subfolder.
 
 ## Common Tasks
 - For a new PDF, create a notes Markdown file and follow the protocol table structure.


### PR DESCRIPTION
## Summary
- revise `lecture-slides/AGENTS.md` to point notes to the `notes/` folder and clarify the `slide_review_protocol.md` governs note formatting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68576688aee08332a05f08496ae589dd