### PR TITLE
Update weekly quizzes agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Every major folder contains its own `AGENTS.md` describing modules, APIs and com
 - `migration_protocol/` – guidelines for converting Google Apps Script lessons to HTML/JS. See `migration_protocol/AGENTS.md`.
 - `scripts/` – utility modules and validation scripts. `scripts/AGENTS.md` covers how to run the tools, including quiz building.
 - `online-lessons/` – migrated lesson packages. Refer to its `AGENTS.md` when editing these modules.
-- `weekly-quizzes/` – holds Brightspace quiz CSVs created from the quiz builder. Check its `AGENTS.md` for conventions.
+ - `weekly-quizzes/` – stores Brightspace quiz CSVs **and** the LaTeX question sets that generate them. See its `AGENTS.md` for the workflow from drafting questions to CSV output.
 - Styling conventions live in `DESIGN_README.md`.
 
 For building quiz CSV files from LaTeX or HTML, follow the dedicated instructions in `instructions/agents/AGENTS.md`.

--- a/weekly-quizzes/AGENTS.md
+++ b/weekly-quizzes/AGENTS.md
@@ -1,13 +1,21 @@
 # AGENTS.md – weekly-quizzes
 
 ## Mission
-Store Brightspace-ready quiz CSV files for each week.
+Store Brightspace-ready quiz CSV files for each week and track the LaTeX question sets that produce them.
 
 ## Key References
 - `readme.md` summarises the folder purpose.
 - Use the quiz builder instructions in `instructions/agents/AGENTS.md` and the API in `scripts/module_quiz_builder_to_csv.py` when creating new quizzes.
 - Follow `question_set_protocol.md` to build the LaTeX question set for each week before converting to CSV.
 
+## Workflow Summary
+1. **Create question sets** – generate a `.tex` file using `question_set_protocol.md`. These question sets capture new material from the lecture slides.
+2. **Transform to CSV** – convert completed question sets to Brightspace CSV format using the quiz builder script. This step is separate from authoring the questions.
+
 ## Common Tasks
-- Add new CSV files named by week (e.g., `week01_quiz.csv`).
-- Use `question_log.md` to note where each quiz question originated and document any manual edits.
+- Add or update LaTeX question sets (`weekXX_quiz.tex`) as new material is covered.
+- Produce Brightspace-ready CSV files named by week (e.g., `week01_quiz.csv`).
+- Record each question source and manual edits in `question_log.md`.
+- Include a brief notes file for each week describing slide references and choices of question types.
+
+These steps keep weekly quizzes organised from draft questions to final CSV imports.


### PR DESCRIPTION
## Summary
- clarify that weekly quizzes folder contains LaTeX question sets and Brightspace CSVs
- outline workflow and common tasks for creating question sets and converting them to CSV

## Testing
- `python3 scripts/validate_intro_inference.py`

------
https://chatgpt.com/codex/tasks/task_e_6857698cb3248332952b2c2fce1a1f79