### PR TITLE
Add general quiz validation framework

### DIFF
--- a/interactive-problem-sets/AGENTS.md
+++ b/interactive-problem-sets/AGENTS.md
@@ -12,6 +12,6 @@ Create and maintain small web-based problem sets that run directly in the browse
 - Keep the JavaScript question objects in the same shape (`id`, `text`, `options`, `correctAnswer`, `explanation`).
 - Test locally by opening `index.html`. No build step is required.
 - If a folder contains `question_index.csv`, update it whenever you add or remove questions so IDs stay in sync.
-- When modifying numeric problems (e.g., the Introduction to Inference set), run `python3 scripts/validate_intro_inference.py` to verify computed answers.
+ - When modifying numeric problems (e.g., the Introduction to Inference set), run `python3 scripts/validate_quiz.py html path/to/index.html` to verify computed answers.
 
 Follow these guidelines when authoring new interactive exercises.

--- a/scripts/quiz_validator.py
+++ b/scripts/quiz_validator.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+import csv
+import re
+from math import sqrt
+from statistics import NormalDist
+
+from inference_utils import (
+    se_mean,
+    prob_mean_exceeds,
+    confidence_interval_proportion,
+    z_test_proportion,
+    sample_size_for_moe,
+    z_critical,
+    se_proportion,
+)
+
+
+class QuizValidator(ABC):
+    """Abstract base class for quiz validation."""
+
+    def __init__(self, output_csv: Path):
+        self.output_csv = Path(output_csv)
+
+    @abstractmethod
+    def parse_answers(self) -> dict[int, str]:
+        """Return mapping of question id to recorded answer letter."""
+
+    @abstractmethod
+    def compute_answers(self) -> dict[int, str]:
+        """Return mapping of question id to calculated answer letter."""
+
+    def write_report(self, parsed: dict[int, str], computed: dict[int, str]) -> None:
+        with self.output_csv.open("w", newline="") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(["question_id", "file_answer", "calculated_answer", "match"])
+            for qid in sorted(computed):
+                file_ans = parsed.get(qid)
+                calc_ans = computed[qid]
+                writer.writerow([qid, file_ans, calc_ans, file_ans == calc_ans])
+
+    def validate(self) -> None:
+        parsed = self.parse_answers()
+        computed = self.compute_answers()
+        self.write_report(parsed, computed)
+
+
+class HtmlQuizValidator(QuizValidator):
+    def __init__(self, html_file: Path, output_csv: Path):
+        super().__init__(output_csv)
+        self.html_file = Path(html_file)
+
+    def parse_answers(self) -> dict[int, str]:
+        text = self.html_file.read_text()
+        pattern = re.compile(r"{\s*id:\s*(\d+).*?correctAnswer:\s*\"([a-d])\"", re.S)
+        return {int(qid): ans for qid, ans in re.findall(pattern, text)}
+
+    def compute_answers(self) -> dict[int, str]:
+        calc: dict[int, str] = {}
+        # Q4: SE of mean
+        se = se_mean(10, 100)
+        if abs(se - 1) < 1e-6:
+            calc[4] = "c"
+        # Q5: Probability mean exceeds 52
+        prob = prob_mean_exceeds(52, 50, 10, 100)
+        if abs(prob - 0.023) < 0.005:
+            calc[5] = "b"
+        # Q6: 95% CI for proportion
+        p_hat = 120 / 400
+        ci = confidence_interval_proportion(p_hat, 400)
+        if abs(ci[0] - 0.255) < 0.005 and abs(ci[1] - 0.345) < 0.005:
+            calc[6] = "b"
+        # Q7: Z test statistic for proportion
+        z = z_test_proportion(0.48, 1000, 0.5)
+        if abs(z + 1.27) < 0.05:
+            calc[7] = "a"
+        # Q9: required sample size for MOE 0.05
+        n_required = sample_size_for_moe(0.05, p=0.5)
+        if n_required == 385:
+            calc[9] = "c"
+        # Q19: Z critical value for 99% CI
+        zcrit = z_critical(0.01)
+        if abs(zcrit - 2.576) < 0.01:
+            calc[19] = "c"
+        return calc
+
+
+class LatexQuizValidator(QuizValidator):
+    def __init__(self, quiz_tex: Path, answers_tex: Path, output_csv: Path):
+        super().__init__(output_csv)
+        self.quiz_tex = Path(quiz_tex)
+        self.answers_tex = Path(answers_tex)
+
+    def parse_answers(self) -> dict[int, str]:
+        text = self.answers_tex.read_text()
+        letters = re.findall(r"\\item\s*([A-D])", text)
+        return {i + 1: letter.lower() for i, letter in enumerate(letters)}
+
+    def compute_answers(self) -> dict[int, str]:
+        norm = NormalDist()
+        calc: dict[int, str] = {}
+        # Q6
+        p_hat6 = 66 / 120
+        se6 = se_proportion(p_hat6, 120)
+        if abs(p_hat6 - 0.55) < 0.01 and abs(se6 - 0.045) < 0.005:
+            calc[6] = "a"
+        # Q7
+        ci7 = confidence_interval_proportion(p_hat6, 120, alpha=0.05)
+        if abs(ci7[0] - 0.46) < 0.01 and abs(ci7[1] - 0.64) < 0.01:
+            calc[7] = "a"
+        # Q8
+        p_hat8 = 220 / 400
+        ci99 = confidence_interval_proportion(p_hat8, 400, alpha=0.01)
+        if abs(ci99[0] - 0.49) < 0.01 and abs(ci99[1] - 0.61) < 0.01:
+            calc[8] = "a"
+        # Q9
+        z9 = z_test_proportion(0.52, 1000, 0.49)
+        if abs(z9 - 1.9) < 0.1 and abs(z9) < z_critical(0.05):
+            calc[9] = "a"
+        # Q10
+        z10 = z_test_proportion(0.53, 1000, 0.50)
+        p10 = 1 - norm.cdf(z10)
+        if abs(p10 - 0.03) < 0.02 and p10 < 0.05:
+            calc[10] = "a"
+        # Q12
+        p_hat12 = 245 / 500
+        se12 = se_proportion(p_hat12, 500)
+        if abs(p_hat12 - 0.49) < 0.01 and abs(se12 - 0.022) < 0.005:
+            calc[12] = "a"
+        # Q13
+        ci13 = confidence_interval_proportion(p_hat12, 500, alpha=0.10)
+        if abs(ci13[0] - 0.45) < 0.01 and abs(ci13[1] - 0.53) < 0.01:
+            calc[13] = "a"
+        # Q14
+        z14 = z_test_proportion(p_hat12, 500, 0.5)
+        if abs(z14 + 0.45) < 0.1 and abs(z14) < z_critical(0.05):
+            calc[14] = "a"
+        # Q17
+        n17 = sample_size_for_moe(0.02, p=0.5, alpha=0.05)
+        if abs(n17 - 2400) <= 1:
+            calc[17] = "c"
+        # Q19
+        sd19 = sqrt(500 * 0.60 * 0.40)
+        if abs(sd19 - 11) < 1:
+            calc[19] = "a"
+        return calc

--- a/scripts/validate_intro_inference.py
+++ b/scripts/validate_intro_inference.py
@@ -1,68 +1,8 @@
-import csv
-import re
 from pathlib import Path
-
-from inference_utils import (
-    se_mean,
-    prob_mean_exceeds,
-    confidence_interval_proportion,
-    z_test_proportion,
-    sample_size_for_moe,
-    z_critical,
-)
+from quiz_validator import HtmlQuizValidator
 
 HTML_FILE = Path('interactive-problem-sets/introduction-to-inference/index.html')
 OUTPUT_CSV = Path('intro_inference_validation.csv')
 
-
-def parse_correct_answers(html_text: str):
-    pattern = re.compile(r'{\s*id:\s*(\d+).*?correctAnswer:\s*"([a-d])"', re.S)
-    return {int(qid): ans for qid, ans in re.findall(pattern, html_text)}
-
-
-def main():
-    html_text = HTML_FILE.read_text()
-    answers = parse_correct_answers(html_text)
-
-    # Hard-coded calculations for numeric questions
-    calculated = {}
-
-    # Q4: SE of mean
-    se = se_mean(10, 100)
-    calculated[4] = 'c' if abs(se - 1) < 1e-6 else None
-
-    # Q5: Probability mean exceeds 52
-    prob = prob_mean_exceeds(52, 50, 10, 100)
-    calculated[5] = 'b' if abs(prob - 0.023) < 0.005 else None
-
-    # Q6: 95% CI for proportion
-    p_hat = 120 / 400
-    ci = confidence_interval_proportion(p_hat, 400)
-    if abs(ci[0] - 0.255) < 0.005 and abs(ci[1] - 0.345) < 0.005:
-        calculated[6] = 'b'
-    else:
-        calculated[6] = None
-
-    # Q7: Z test statistic for proportion
-    z = z_test_proportion(0.48, 1000, 0.5)
-    calculated[7] = 'a' if abs(z + 1.27) < 0.05 else None
-
-    # Q9: required sample size for MOE 0.05
-    n_required = sample_size_for_moe(0.05, p=0.5)
-    calculated[9] = 'c' if n_required == 385 else None
-
-    # Q19: Z critical value for 99% CI
-    zcrit = z_critical(0.01)
-    calculated[19] = 'c' if abs(zcrit - 2.576) < 0.01 else None
-
-    with OUTPUT_CSV.open('w', newline='') as csvfile:
-        writer = csv.writer(csvfile)
-        writer.writerow(['question_id', 'html_answer', 'calculated_answer', 'match'])
-        for qid in sorted(calculated):
-            html_ans = answers.get(qid)
-            calc_ans = calculated[qid]
-            writer.writerow([qid, html_ans, calc_ans, html_ans == calc_ans])
-
-
 if __name__ == '__main__':
-    main()
+    HtmlQuizValidator(HTML_FILE, OUTPUT_CSV).validate()

--- a/scripts/validate_quiz.py
+++ b/scripts/validate_quiz.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import argparse
+
+from quiz_validator import HtmlQuizValidator, LatexQuizValidator
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate quiz answer files")
+    subparsers = parser.add_subparsers(dest="format", required=True)
+
+    html_p = subparsers.add_parser("html", help="Validate HTML problem set")
+    html_p.add_argument("html_file", type=Path)
+    html_p.add_argument("--output", "-o", type=Path, default=Path("validation_report.csv"))
+
+    tex_p = subparsers.add_parser("latex", help="Validate LaTeX quiz")
+    tex_p.add_argument("quiz_file", type=Path)
+    tex_p.add_argument("answers_file", type=Path)
+    tex_p.add_argument("--output", "-o", type=Path, default=Path("validation_report.csv"))
+
+    args = parser.parse_args()
+
+    if args.format == "html":
+        validator = HtmlQuizValidator(args.html_file, args.output)
+    else:
+        validator = LatexQuizValidator(args.quiz_file, args.answers_file, args.output)
+
+    validator.validate()
+    print(f"Report written to {validator.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validation_protocol.md
+++ b/scripts/validation_protocol.md
@@ -1,28 +1,22 @@
-# Introduction to Inference Problem Set Validation Protocol
+# Quiz Validation Protocol
 
-This document describes the procedure used to verify that the hard-coded answers in
-`interactive-problem-sets/introduction-to-inference/index.html` match the results of
-independent calculations.
+This document explains how to verify that multiple-choice answers match the numeric computations used in the course materials. Validation supports both interactive HTML problem sets and the LaTeX question sets for weekly quizzes.
 
-## Steps
+## Utility Modules
+- `scripts/inference_utils.py` contains helpers for standard errors, confidence intervals and hypothesis tests.
+- `scripts/quiz_validator.py` implements `HtmlQuizValidator` and `LatexQuizValidator` used by the command line tool.
 
-1. **Utility Module** – `scripts/inference_utils.py`
-   - Provides helper functions for standard errors, confidence intervals,
-     hypothesis tests and required sample sizes derived from Lecture Slides 7 and 8.
-   - Functions rely only on Python's standard library (`math` and `statistics`).
+## Command Line Tool
+Use `scripts/validate_quiz.py` with the desired format and file paths.
 
-2. **Validation Script** – `scripts/validate_intro_inference.py`
-   - Parses the HTML file for each question's `id` and `correctAnswer` letter.
-   - Recreates all numeric problems from the HTML with hard-coded parameters and
-     computes answers using functions from `inference_utils`.
-   - Writes `intro_inference_validation.csv` summarising the HTML answer,
-     the calculated answer and whether they match for each numeric question.
-
-3. **Running Validation**
-
+### HTML Example
 ```bash
-python3 scripts/validate_intro_inference.py
+python3 scripts/validate_quiz.py html interactive-problem-sets/introduction-to-inference/index.html -o intro_inference_validation.csv
 ```
 
-The script produces `intro_inference_validation.csv` in the repository root.
-Any discrepancy will appear with `False` in the `match` column.
+### LaTeX Example
+```bash
+python3 scripts/validate_quiz.py latex weekly-quizzes/week04_quiz.tex weekly-quizzes/week04_answers.tex -o week04_validation.csv
+```
+
+The script writes a CSV report with columns `question_id`, `file_answer`, `calculated_answer` and `match`. The helper `validate_intro_inference.py` remains as a shortcut for validating the Introduction to Inference set.


### PR DESCRIPTION
## Summary
- add an abstract `QuizValidator` with HTML and LaTeX subclasses
- port intro-to-inference numeric checks into `HtmlQuizValidator`
- implement LaTeX logic for week04
- create a CLI `validate_quiz.py` and slim down the old helper
- document new workflow in `validation_protocol.md`
- update interactive-problem-sets guidance

## Testing
- `python3 scripts/validate_quiz.py html interactive-problem-sets/introduction-to-inference/index.html -o /tmp/validation.csv`
- `python3 scripts/validate_quiz.py latex weekly-quizzes/week04_quiz.tex weekly-quizzes/week04_answers.tex -o /tmp/week04.csv`


------
https://chatgpt.com/codex/tasks/task_e_6857727631908332885195e8e20bd0c9