### PR TITLE
Update README files for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@ This repository stores materials for the POL201 statistics course. The content i
 
 ## Folder Overview
 
-- **interactive-problem-sets/** – small standalone web exercises. Currently contains a probability problem set and a placeholder for inference for one proportion.
+- **interactive-problem-sets/** – small standalone web exercises. Includes a probability set, an introduction to inference set and a placeholder for inference for one proportion.
 - **lecture-slides/** – PDF slide decks for each lecture.
 - **migration_protocol/** – documentation describing how Google Apps Script lessons were migrated to static HTML/JS along with a database of videos and questions.
-- **online-lessons/** – reserved for future fully online lessons (currently empty).
-- **pol201_lesson_week4_part1**, **part2**, **part3** – original Google Apps Script projects for Week 4, split into three parts.
-- **pol201_lesson_week4_part1_htmljs**, **part2_htmljs**, **part3_htmljs** – HTML/JavaScript versions of the same lessons for embedding into Brightspace.
-- **weekly-quizzes/** – placeholder for weekly quiz files.
+- **online-lessons/** – fully online lesson packages. This folder now holds the Week&nbsp;4 lessons in both Google Apps Script and HTML/JS forms.
+- **weekly-quizzes/** – LaTeX question sets, notes and logs used to generate Brightspace quiz CSVs.
 - **styles.css** – shared CSS used by some of the HTML lesson pages.
 
 The `DESIGN_README.md` file outlines styling guidelines used when refreshing the lesson pages.

--- a/interactive-problem-sets/inference-one-proportion/readme.md
+++ b/interactive-problem-sets/inference-one-proportion/readme.md
@@ -1,1 +1,4 @@
+# Inference for One Proportion (Placeholder)
+
+This directory is reserved for a future interactive problem set covering inference for a single proportion. It currently contains no content.
 

--- a/interactive-problem-sets/readme.md
+++ b/interactive-problem-sets/readme.md
@@ -5,6 +5,7 @@ This folder collects small web-based problem sets. Each subfolder contains a sel
 Current directories:
 
 - **probability/** – interactive questions covering basic probability theory.
+- **introduction-to-inference/** – a short set introducing inference concepts.
 - **inference-one-proportion/** – placeholder for a future exercise.
 - **style.css** – minimal shared styling used by the sets.
 

--- a/intro_inference_validation.csv
+++ b/intro_inference_validation.csv
@@ -1,4 +1,4 @@
-question_id,html_answer,calculated_answer,match
+question_id,file_answer,calculated_answer,match
 4,c,c,True
 5,b,b,True
 6,b,b,True

--- a/weekly-quizzes/readme.md
+++ b/weekly-quizzes/readme.md
@@ -1,3 +1,13 @@
 # Weekly Quizzes
 
-This folder will contain short quizzes for each week of the course.  This read me requires an update.
+This folder stores the LaTeX question sets and supporting notes used to build weekly Brightspace quizzes.
+
+Current files include material for Week&nbsp;4:
+
+- `week04_quiz.tex` – multiple choice questions in LaTeX format.
+- `week04_answers.tex` – solutions for the Week&nbsp;4 quiz.
+- `week04_notes.md` – slide references and additional notes.
+- `question_log.md` – running list mapping each question to its source slide.
+- `question_set_protocol.md` – guidelines for preparing new question sets.
+
+Convert question sets to CSV using `scripts/module_quiz_builder_to_csv.py` when ready for Brightspace import.


### PR DESCRIPTION
## Summary
- clarify repo overview in `README.md`
- mention intro to inference set in interactive problem sets
- add placeholder description for inference-one-proportion set
- expand weekly quizzes README
- regenerate validation CSV after running script

## Testing
- `python3 scripts/validate_intro_inference.py && ls -l intro_inference_validation.csv`

------
https://chatgpt.com/codex/tasks/task_e_6857747ca1708332ad91fe60bb79921a