### PR TITLE
Extend inference utilities for mean-based procedures

### DIFF
--- a/scripts/inference_utils.py
+++ b/scripts/inference_utils.py
@@ -1,5 +1,6 @@
 from math import sqrt, ceil
 from statistics import NormalDist
+from scipy.stats import t as _t_dist
 
 _norm = NormalDist()
 
@@ -44,3 +45,127 @@ def sample_size_for_moe(moe: float, p: float = 0.5, alpha: float = 0.05) -> int:
 def z_critical(alpha: float) -> float:
     """Two-sided z critical value for significance level alpha."""
     return _norm.inv_cdf(1 - alpha / 2)
+
+
+def se_diff_means(sd1: float, n1: int, sd2: float, n2: int) -> float:
+    """Standard error of the difference between two sample means."""
+    return sqrt(sd1 ** 2 / n1 + sd2 ** 2 / n2)
+
+
+def confidence_interval_mean(x_bar: float, sample_sd: float, n: int, alpha: float = 0.05):
+    """Large-sample confidence interval for a population mean."""
+    z = z_critical(alpha)
+    se = se_mean(sample_sd, n)
+    moe = z * se
+    return x_bar - moe, x_bar + moe
+
+
+def z_test_mean(x_bar: float, sample_sd: float, n: int, mu0: float) -> float:
+    """Z test statistic for a population mean."""
+    se = se_mean(sample_sd, n)
+    return (x_bar - mu0) / se
+
+
+def confidence_interval_diff_means(
+    x_bar1: float,
+    sample_sd1: float,
+    n1: int,
+    x_bar2: float,
+    sample_sd2: float,
+    n2: int,
+    alpha: float = 0.05,
+):
+    """Large-sample confidence interval for the difference of two means."""
+    diff = x_bar1 - x_bar2
+    z = z_critical(alpha)
+    se = se_diff_means(sample_sd1, n1, sample_sd2, n2)
+    moe = z * se
+    return diff - moe, diff + moe
+
+
+def z_test_diff_means(
+    x_bar1: float,
+    sample_sd1: float,
+    n1: int,
+    x_bar2: float,
+    sample_sd2: float,
+    n2: int,
+    diff0: float = 0.0,
+) -> float:
+    """Z test statistic for comparing two means."""
+    diff = x_bar1 - x_bar2
+    se = se_diff_means(sample_sd1, n1, sample_sd2, n2)
+    return (diff - diff0) / se
+
+
+def t_critical(alpha: float, df: int) -> float:
+    """Two-sided t critical value with given degrees of freedom."""
+    return _t_dist.ppf(1 - alpha / 2, df)
+
+
+def t_confidence_interval_mean(x_bar: float, sample_sd: float, n: int, alpha: float = 0.05):
+    """Small-sample confidence interval for a population mean (t-distribution)."""
+    t = t_critical(alpha, n - 1)
+    se = se_mean(sample_sd, n)
+    moe = t * se
+    return x_bar - moe, x_bar + moe
+
+
+def t_test_mean(x_bar: float, sample_sd: float, n: int, mu0: float) -> float:
+    """t statistic for testing a population mean."""
+    se = se_mean(sample_sd, n)
+    return (x_bar - mu0) / se
+
+
+def _welch_df(sd1: float, n1: int, sd2: float, n2: int) -> float:
+    var1 = sd1 ** 2 / n1
+    var2 = sd2 ** 2 / n2
+    return (var1 + var2) ** 2 / (var1 ** 2 / (n1 - 1) + var2 ** 2 / (n2 - 1))
+
+
+def t_confidence_interval_diff_means(
+    x_bar1: float,
+    sample_sd1: float,
+    n1: int,
+    x_bar2: float,
+    sample_sd2: float,
+    n2: int,
+    alpha: float = 0.05,
+):
+    """Welch confidence interval for difference of two means."""
+    diff = x_bar1 - x_bar2
+    se = se_diff_means(sample_sd1, n1, sample_sd2, n2)
+    df = _welch_df(sample_sd1, n1, sample_sd2, n2)
+    t = t_critical(alpha, df)
+    moe = t * se
+    return diff - moe, diff + moe
+
+
+def t_test_diff_means(
+    x_bar1: float,
+    sample_sd1: float,
+    n1: int,
+    x_bar2: float,
+    sample_sd2: float,
+    n2: int,
+    diff0: float = 0.0,
+):
+    """Welch t statistic for testing difference of two means."""
+    diff = x_bar1 - x_bar2
+    se = se_diff_means(sample_sd1, n1, sample_sd2, n2)
+    df = _welch_df(sample_sd1, n1, sample_sd2, n2)
+    return (diff - diff0) / se, df
+
+
+def t_confidence_interval_paired(diff_mean: float, sd_diff: float, n: int, alpha: float = 0.05):
+    """Confidence interval for mean paired difference."""
+    t = t_critical(alpha, n - 1)
+    se = se_mean(sd_diff, n)
+    moe = t * se
+    return diff_mean - moe, diff_mean + moe
+
+
+def t_test_paired(diff_mean: float, sd_diff: float, n: int, diff0: float = 0.0) -> float:
+    """t statistic for mean paired difference."""
+    se = se_mean(sd_diff, n)
+    return (diff_mean - diff0) / se


### PR DESCRIPTION
## Summary
- add optional SciPy import in `inference_utils`
- implement z- and t-based mean inference helpers
- include functions for paired data and Welch's method
- **remove try/except fallback and require SciPy**

## Testing
- `python3 -m py_compile scripts/inference_utils.py`
- `python3 - <<'PY'
import sys
sys.path.append('scripts')
from inference_utils import z_critical, confidence_interval_mean, t_critical, t_confidence_interval_mean, t_confidence_interval_diff_means, t_test_diff_means
print('z crit 0.05', z_critical(0.05))
print('CI mean large', confidence_interval_mean(50, 10, 100))
print('t crit 0.05 df=11', round(t_critical(0.05, 11),3))
print('t CI mean small', t_confidence_interval_mean(7.8, 3.1, 12))
print('t Welch diff', t_confidence_interval_diff_means(77.3, 8.4, 12, 70.1, 7.1, 15))
print('t test diff', t_test_diff_means(77.3, 8.4, 12, 70.1, 7.1, 15))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685780bec5a48332877b40d388d21a3e