### PR TITLE
Modularize quiz validator

### DIFF
--- a/interactive-problem-sets/AGENTS.md
+++ b/interactive-problem-sets/AGENTS.md
@@ -12,6 +12,6 @@ Create and maintain small web-based problem sets that run directly in the browse
 - Keep the JavaScript question objects in the same shape (`id`, `text`, `options`, `correctAnswer`, `explanation`).
 - Test locally by opening `index.html`. No build step is required.
 - If a folder contains `question_index.csv`, update it whenever you add or remove questions so IDs stay in sync.
- - When modifying numeric problems (e.g., the Introduction to Inference set), run `python3 scripts/validate_quiz.py html path/to/index.html` to verify computed answers.
+ - When modifying numeric problems (e.g., the Introduction to Inference set), run `python3 scripts/validate_intro_inference.py` to verify computed answers.
 
 Follow these guidelines when authoring new interactive exercises.

--- a/interactive-problem-sets/readme.md
+++ b/interactive-problem-sets/readme.md
@@ -35,6 +35,6 @@ Each problem set is built from a single HTML page with inline JavaScript. The la
 3. **Add formulas** directly in the `text` or `explanation` fields using LaTeX syntax if needed.
 4. **Test locally** by opening `index.html` in a browser. No build step is required since everything is plain HTML and JavaScript.
 5. If the folder uses a `question_index.csv` file, update it whenever questions change so IDs stay consistent.
-6. For numeric questions, run `python3 scripts/validate_quiz.py html path/to/index.html` to verify computed answers.
+6. For numeric questions, run `python3 scripts/validate_intro_inference.py` to verify computed answers.
 
 Following these guidelines, you can quickly author additional interactive problem sets without modifying the underlying script logic.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -17,8 +17,10 @@ Use the Python module in this folder directly.
 - Run `python3 validate_intro_inference.py` to check the introduction to inference
   problem set. The script reads `interactive-problem-sets/introduction-to-inference/index.html`,
   computes numeric answers with functions from `inference_utils.py` and writes
-  `intro_inference_validation.csv` summarising whether each answer matches the
-  HTML.
+   `intro_inference_validation.csv` summarising whether each answer matches the
+   HTML.
+- Run `python3 validate_week04.py` to validate the Week 4 LaTeX quiz. The script
+  saves `week04_validation.csv` comparing calculated answers to the key.
 
 - When building quizzes, import `module_quiz_builder_to_csv.py` and assemble the
   questions using its dataclasses (`QuestionBank`, `MultipleChoice`, `TFOption`,

--- a/scripts/quiz_validator.py
+++ b/scripts/quiz_validator.py
@@ -1,21 +1,11 @@
 from __future__ import annotations
 
+"""Utility classes for validating quiz answer files."""
+
 from abc import ABC, abstractmethod
 from pathlib import Path
 import csv
 import re
-from math import sqrt
-from statistics import NormalDist
-
-from inference_utils import (
-    se_mean,
-    prob_mean_exceeds,
-    confidence_interval_proportion,
-    z_test_proportion,
-    sample_size_for_moe,
-    z_critical,
-    se_proportion,
-)
 
 
 class QuizValidator(ABC):
@@ -57,34 +47,9 @@ class HtmlQuizValidator(QuizValidator):
         pattern = re.compile(r"{\s*id:\s*(\d+).*?correctAnswer:\s*\"([a-d])\"", re.S)
         return {int(qid): ans for qid, ans in re.findall(pattern, text)}
 
+    @abstractmethod
     def compute_answers(self) -> dict[int, str]:
-        calc: dict[int, str] = {}
-        # Q4: SE of mean
-        se = se_mean(10, 100)
-        if abs(se - 1) < 1e-6:
-            calc[4] = "c"
-        # Q5: Probability mean exceeds 52
-        prob = prob_mean_exceeds(52, 50, 10, 100)
-        if abs(prob - 0.023) < 0.005:
-            calc[5] = "b"
-        # Q6: 95% CI for proportion
-        p_hat = 120 / 400
-        ci = confidence_interval_proportion(p_hat, 400)
-        if abs(ci[0] - 0.255) < 0.005 and abs(ci[1] - 0.345) < 0.005:
-            calc[6] = "b"
-        # Q7: Z test statistic for proportion
-        z = z_test_proportion(0.48, 1000, 0.5)
-        if abs(z + 1.27) < 0.05:
-            calc[7] = "a"
-        # Q9: required sample size for MOE 0.05
-        n_required = sample_size_for_moe(0.05, p=0.5)
-        if n_required == 385:
-            calc[9] = "c"
-        # Q19: Z critical value for 99% CI
-        zcrit = z_critical(0.01)
-        if abs(zcrit - 2.576) < 0.01:
-            calc[19] = "c"
-        return calc
+        """Return mapping of question id to calculated answer letter."""
 
 
 class LatexQuizValidator(QuizValidator):
@@ -98,51 +63,6 @@ class LatexQuizValidator(QuizValidator):
         letters = re.findall(r"\\item\s*([A-D])", text)
         return {i + 1: letter.lower() for i, letter in enumerate(letters)}
 
+    @abstractmethod
     def compute_answers(self) -> dict[int, str]:
-        norm = NormalDist()
-        calc: dict[int, str] = {}
-        # Q6
-        p_hat6 = 66 / 120
-        se6 = se_proportion(p_hat6, 120)
-        if abs(p_hat6 - 0.55) < 0.01 and abs(se6 - 0.045) < 0.005:
-            calc[6] = "a"
-        # Q7
-        ci7 = confidence_interval_proportion(p_hat6, 120, alpha=0.05)
-        if abs(ci7[0] - 0.46) < 0.01 and abs(ci7[1] - 0.64) < 0.01:
-            calc[7] = "a"
-        # Q8
-        p_hat8 = 220 / 400
-        ci99 = confidence_interval_proportion(p_hat8, 400, alpha=0.01)
-        if abs(ci99[0] - 0.49) < 0.01 and abs(ci99[1] - 0.61) < 0.01:
-            calc[8] = "a"
-        # Q9
-        z9 = z_test_proportion(0.52, 1000, 0.49)
-        if abs(z9 - 1.9) < 0.1 and abs(z9) < z_critical(0.05):
-            calc[9] = "a"
-        # Q10
-        z10 = z_test_proportion(0.53, 1000, 0.50)
-        p10 = 1 - norm.cdf(z10)
-        if abs(p10 - 0.03) < 0.02 and p10 < 0.05:
-            calc[10] = "a"
-        # Q12
-        p_hat12 = 245 / 500
-        se12 = se_proportion(p_hat12, 500)
-        if abs(p_hat12 - 0.49) < 0.01 and abs(se12 - 0.022) < 0.005:
-            calc[12] = "a"
-        # Q13
-        ci13 = confidence_interval_proportion(p_hat12, 500, alpha=0.10)
-        if abs(ci13[0] - 0.45) < 0.01 and abs(ci13[1] - 0.53) < 0.01:
-            calc[13] = "a"
-        # Q14
-        z14 = z_test_proportion(p_hat12, 500, 0.5)
-        if abs(z14 + 0.45) < 0.1 and abs(z14) < z_critical(0.05):
-            calc[14] = "a"
-        # Q17
-        n17 = sample_size_for_moe(0.02, p=0.5, alpha=0.05)
-        if abs(n17 - 2400) <= 1:
-            calc[17] = "c"
-        # Q19
-        sd19 = sqrt(500 * 0.60 * 0.40)
-        if abs(sd19 - 11) < 1:
-            calc[19] = "a"
-        return calc
+        """Return mapping of question id to calculated answer letter."""

--- a/scripts/validate_intro_inference.py
+++ b/scripts/validate_intro_inference.py
@@ -1,8 +1,42 @@
 from pathlib import Path
+
 from quiz_validator import HtmlQuizValidator
+from inference_utils import (
+    se_mean,
+    prob_mean_exceeds,
+    confidence_interval_proportion,
+    z_test_proportion,
+    sample_size_for_moe,
+    z_critical,
+)
+
+
+class IntroInferenceValidator(HtmlQuizValidator):
+    def compute_answers(self) -> dict[int, str]:
+        calc: dict[int, str] = {}
+        se = se_mean(10, 100)
+        if abs(se - 1) < 1e-6:
+            calc[4] = "c"
+        prob = prob_mean_exceeds(52, 50, 10, 100)
+        if abs(prob - 0.023) < 0.005:
+            calc[5] = "b"
+        p_hat = 120 / 400
+        ci = confidence_interval_proportion(p_hat, 400)
+        if abs(ci[0] - 0.255) < 0.005 and abs(ci[1] - 0.345) < 0.005:
+            calc[6] = "b"
+        z = z_test_proportion(0.48, 1000, 0.5)
+        if abs(z + 1.27) < 0.05:
+            calc[7] = "a"
+        n_required = sample_size_for_moe(0.05, p=0.5)
+        if n_required == 385:
+            calc[9] = "c"
+        zcrit = z_critical(0.01)
+        if abs(zcrit - 2.576) < 0.01:
+            calc[19] = "c"
+        return calc
 
 HTML_FILE = Path('interactive-problem-sets/introduction-to-inference/index.html')
 OUTPUT_CSV = Path('intro_inference_validation.csv')
 
 if __name__ == '__main__':
-    HtmlQuizValidator(HTML_FILE, OUTPUT_CSV).validate()
+    IntroInferenceValidator(HTML_FILE, OUTPUT_CSV).validate()

--- a/scripts/validate_week04.py
+++ b/scripts/validate_week04.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+from math import sqrt
+from statistics import NormalDist
+
+from quiz_validator import LatexQuizValidator
+from inference_utils import (
+    se_proportion,
+    confidence_interval_proportion,
+    z_test_proportion,
+    sample_size_for_moe,
+    z_critical,
+)
+
+
+class Week04Validator(LatexQuizValidator):
+    def compute_answers(self) -> dict[int, str]:
+        norm = NormalDist()
+        calc: dict[int, str] = {}
+        p_hat6 = 66 / 120
+        se6 = se_proportion(p_hat6, 120)
+        if abs(p_hat6 - 0.55) < 0.01 and abs(se6 - 0.045) < 0.005:
+            calc[6] = "a"
+        ci7 = confidence_interval_proportion(p_hat6, 120, alpha=0.05)
+        if abs(ci7[0] - 0.46) < 0.01 and abs(ci7[1] - 0.64) < 0.01:
+            calc[7] = "a"
+        p_hat8 = 220 / 400
+        ci99 = confidence_interval_proportion(p_hat8, 400, alpha=0.01)
+        if abs(ci99[0] - 0.49) < 0.01 and abs(ci99[1] - 0.61) < 0.01:
+            calc[8] = "a"
+        z9 = z_test_proportion(0.52, 1000, 0.49)
+        if abs(z9 - 1.9) < 0.1 and abs(z9) < z_critical(0.05):
+            calc[9] = "a"
+        z10 = z_test_proportion(0.53, 1000, 0.50)
+        p10 = 1 - norm.cdf(z10)
+        if abs(p10 - 0.03) < 0.02 and p10 < 0.05:
+            calc[10] = "a"
+        p_hat12 = 245 / 500
+        se12 = se_proportion(p_hat12, 500)
+        if abs(p_hat12 - 0.49) < 0.01 and abs(se12 - 0.022) < 0.005:
+            calc[12] = "a"
+        ci13 = confidence_interval_proportion(p_hat12, 500, alpha=0.10)
+        if abs(ci13[0] - 0.45) < 0.01 and abs(ci13[1] - 0.53) < 0.01:
+            calc[13] = "a"
+        z14 = z_test_proportion(p_hat12, 500, 0.5)
+        if abs(z14 + 0.45) < 0.1 and abs(z14) < z_critical(0.05):
+            calc[14] = "a"
+        n17 = sample_size_for_moe(0.02, p=0.5, alpha=0.05)
+        if abs(n17 - 2400) <= 1:
+            calc[17] = "c"
+        sd19 = sqrt(500 * 0.60 * 0.40)
+        if abs(sd19 - 11) < 1:
+            calc[19] = "a"
+        return calc
+
+
+QUIZ_TEX = Path("weekly-quizzes/week04_quiz.tex")
+ANSWERS_TEX = Path("weekly-quizzes/week04_answers.tex")
+OUTPUT_CSV = Path("week04_validation.csv")
+
+if __name__ == "__main__":
+    Week04Validator(QUIZ_TEX, ANSWERS_TEX, OUTPUT_CSV).validate()

--- a/scripts/validation_protocol.md
+++ b/scripts/validation_protocol.md
@@ -6,17 +6,18 @@ This document explains how to verify that multiple-choice answers match the nume
 - `scripts/inference_utils.py` contains helpers for standard errors, confidence intervals and hypothesis tests.
 - `scripts/quiz_validator.py` implements `HtmlQuizValidator` and `LatexQuizValidator` used by the command line tool.
 
-## Command Line Tool
-Use `scripts/validate_quiz.py` with the desired format and file paths.
+## Command Line Scripts
+Create a validator script for each quiz by subclassing `HtmlQuizValidator` or
+`LatexQuizValidator` from `quiz_validator.py`. Run that script to generate a
+CSV report with columns `question_id`, `file_answer`, `calculated_answer` and
+`match`.
 
 ### HTML Example
 ```bash
-python3 scripts/validate_quiz.py html interactive-problem-sets/introduction-to-inference/index.html -o intro_inference_validation.csv
+python3 scripts/validate_intro_inference.py
 ```
 
 ### LaTeX Example
 ```bash
-python3 scripts/validate_quiz.py latex weekly-quizzes/week04_quiz.tex weekly-quizzes/week04_answers.tex -o week04_validation.csv
+python3 scripts/validate_week04.py
 ```
-
-The script writes a CSV report with columns `question_id`, `file_answer`, `calculated_answer` and `match`. The helper `validate_intro_inference.py` remains as a shortcut for validating the Introduction to Inference set.

--- a/weekly-quizzes/readme.md
+++ b/weekly-quizzes/readme.md
@@ -10,4 +10,4 @@ Current files include material for Week&nbsp;4:
 - `question_log.md` – running list mapping each question to its source slide.
 - `question_set_protocol.md` – guidelines for preparing new question sets.
 
-Convert question sets to CSV using `scripts/module_quiz_builder_to_csv.py` when ready for Brightspace import. See `AGENTS.md` for the full workflow and run `python3 scripts/validate_quiz.py latex your_set.tex your_answers.tex` to confirm numeric solutions before exporting.
+Convert question sets to CSV using `scripts/module_quiz_builder_to_csv.py` when ready for Brightspace import. See `AGENTS.md` for the full workflow and run the appropriate validation script (e.g. `python3 scripts/validate_week04.py`) to confirm numeric solutions before exporting.

--- a/workflow/quiz_question_set_workflow.md
+++ b/workflow/quiz_question_set_workflow.md
@@ -24,7 +24,7 @@ This guide explains how to draft a new quiz question set, log the source slides 
    - Summarise slide references and design choices in `weekXX_notes.md`.
    - Append an entry to `question_log.md` mapping each question to the corresponding slide numbers.
 5. **Validate Numeric Answers** (if applicable)
-   - Run `python3 scripts/validate_quiz.py latex weekXX_quiz.tex weekXX_answers.tex` to ensure computed results match the recorded answers.
+   - Run the week-specific validator (e.g. `python3 scripts/validate_week04.py`) to ensure computed results match the recorded answers.
 6. **Convert to CSV**
    - When the LaTeX set is final, use the workflow in `quiz-builder-module-protocol.md` and the API in `scripts/module_quiz_builder_to_csv.py` to export a Brightspace CSV.
 7. **Store Results**


### PR DESCRIPTION
## Summary
- remove quiz specific logic from `scripts/quiz_validator.py`
- implement `IntroInferenceValidator` and new `Week04Validator`
- document the new validator scripts
- update references to use the week-specific validators

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 scripts/validate_intro_inference.py`
- `python3 scripts/validate_week04.py`


------
https://chatgpt.com/codex/tasks/task_e_6857857edd5083328cf119e390da5869