### PR TITLE
Add markdown export for inference question index

### DIFF
--- a/interactive-problem-sets/introduction-to-inference/question_index.md
+++ b/interactive-problem-sets/introduction-to-inference/question_index.md
@@ -1,0 +1,23 @@
+| id | topic | question_text | question_type | cognitive_domain | correct_answer |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Estimator Properties | Which of the following best describes an unbiased estimator? | MCQ | Conceptual | a |
+| 2 | Estimator Efficiency | Two unbiased estimators A and B estimate the same parameter. If Var(A)=4 and Var(B)=5, which estimator is more efficient? | MCQ | Conceptual | a |
+| 3 | Central Limit Theorem | According to the Central Limit Theorem, what is the approximate sampling distribution of the sample mean for large n when sampling from a population with mean \( \mu \) and standard deviation \( \sigma \)? | MCQ | Conceptual | a |
+| 4 | Standard Error | A random sample of 100 observations has a sample mean of 50 and a sample standard deviation of 10. What is the standard error of the sample mean? | MCQ | Computational | c |
+| 5 | Using the CLT | Using the sample in the previous question and assuming normality, what is the approximate probability that the sample mean exceeds 52? | MCQ | Computational | b |
+| 6 | Confidence Interval for p | A survey of 400 people finds 120 support a policy. What is the 95% confidence interval for the true proportion supporting the policy? | MCQ | Computational | b |
+| 7 | Hypothesis Test for p | A poll reports p-hat = 0.48 from a sample of n = 1000. To test H0: p = 0.5 versus Ha: p \u2260 0.5, what is the value of the Z test statistic? | MCQ | Computational | a |
+| 8 | Hypothesis Test Decision | Using the previous test statistic and \u03b1 = 0.05, what is the correct conclusion? | MCQ | Interpretation | b |
+| 9 | Sample Size Calculation | Approximately how large a sample is required to estimate a population proportion near 0.5 with a margin of error of \u00b10.05 at the 95% confidence level? | MCQ | Computational | c |
+| 10 | P-value Interpretation | If a two-sided test for a proportion yields a P-value of 0.03, what can you conclude at \u03b1 = 0.05? | MCQ | Interpretation | a |
+| 11 | Population vs. Sample | Which of the following best describes a population parameter? | MCQ | Conceptual | a |
+| 12 | Estimator Consistency | Which property means an estimator converges to the true parameter as the sample size increases? | MCQ | Conceptual | c |
+| 13 | Standard Error vs SD | Which statement correctly explains the standard error (SE) of an estimator? | MCQ | Conceptual | b |
+| 14 | CLT Assumptions | Which of the following is NOT an assumption of the Central Limit Theorem (CLT)? | MCQ | Conceptual | c |
+| 15 | Sample Mean Distribution | If X_i \u223c N(50, 25) and n = 16, what is the sampling distribution of \(\bar{X}\)? | MCQ | Conceptual | a |
+| 16 | Law of Large Numbers | According to the Law of Large Numbers, the sample mean \(\bar{X}\) ____. | MCQ | Conceptual | a |
+| 17 | Sample Proportion | The sample proportion \(\hat{p}\) is calculated as: | MCQ | Conceptual | a |
+| 18 | Variance of p-hat | What is the variance of the sample proportion \(\hat{p}\)? | MCQ | Conceptual | a |
+| 19 | 99% Confidence Level | Which Z critical value is used for a 99% confidence interval for a proportion? | MCQ | Conceptual | c |
+| 20 | Interpreting CIs | Which of the following best describes a correct interpretation of a 95% confidence interval for \(p\)? | MCQ | Interpretation | a |
+| 21 | Significance Level | In hypothesis testing, the significance level \u03b1 represents: | MCQ | Conceptual | a |

--- a/scripts/csv_to_md.py
+++ b/scripts/csv_to_md.py
@@ -1,0 +1,25 @@
+import csv
+from pathlib import Path
+
+
+def csv_to_markdown(csv_path: Path, md_path: Path) -> None:
+    """Read a CSV file and write its contents as a markdown table."""
+    with csv_path.open(newline="") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+    if not rows:
+        return
+    headers, body = rows[0], rows[1:]
+    with md_path.open("w") as f:
+        f.write("| " + " | ".join(headers) + " |\n")
+        f.write("|" + " --- |" * len(headers) + "\n")
+        for row in body:
+            f.write("| " + " | ".join(row) + " |\n")
+
+
+if __name__ == "__main__":
+    CSV_FILE = Path(
+        "interactive-problem-sets/introduction-to-inference/question_index.csv"
+    )
+    MD_FILE = CSV_FILE.with_suffix(".md")
+    csv_to_markdown(CSV_FILE, MD_FILE)


### PR DESCRIPTION
## Summary
- generate `question_index.md` for the Introduction to Inference set
- add `csv_to_md.py` utility script in scripts

## Testing
- `python3 scripts/csv_to_md.py`

------
https://chatgpt.com/codex/tasks/task_e_68597e38d6088332b2c993c671bb0165