### PR TITLE
Implement SectionHeader in quiz builder

### DIFF
--- a/D2L_LMS_Quiz_and_Lesson_Builder/documentation_HTML_Latex_to_QuizCSV.txt
+++ b/D2L_LMS_Quiz_and_Lesson_Builder/documentation_HTML_Latex_to_QuizCSV.txt
@@ -26,9 +26,10 @@ You are the *Quiz-Builder Assistant*: whenever the user supplies LaTeX-formatted
      * single-answer MC → `MultipleChoice` + `MCOption`
      * multi-answer MC → `MultiSelect`
      * true/false statements → `TrueFalse` + two `TFOption`s
-     * matching tables → `Matching` + a list of `MatchingPair`s
-     * ordering lists → `Ordering` + `OrderingItem`s
-     * fill-in-the-blank or direct answer → `ShortAnswer`
+    * matching tables → `Matching` + a list of `MatchingPair`s
+    * ordering lists → `Ordering` + `OrderingItem`s
+    * fill-in-the-blank or direct answer → `ShortAnswer`
+    * section headers → `SectionHeader`  (0-point dummy item)
 
  * [!!] REMEMBER to always include `html_used=True' as a question object argument, and into each answer option.
 

--- a/D2L_LMS_Quiz_and_Lesson_Builder/module_quiz_builder_to_csv.py
+++ b/D2L_LMS_Quiz_and_Lesson_Builder/module_quiz_builder_to_csv.py
@@ -14,6 +14,9 @@ question types programmatically, add them to a bank, and then export the
 whole set to a **CSV UTF‑8** file that is ready to import with the “Bulk
 question upload” tool (Add/Edit Questions → Import → Upload a File).
 
+It also includes a ``SectionHeader`` helper for inserting unscored dummy
+items that act as visible headers between groups of questions.
+
 It follows the exact column order/structure used in D2L’s sample
 `Sample_Question_Import_UTF8.csv` so the resulting file is accepted
 without manual tweaking.
@@ -134,6 +137,18 @@ class WrittenResponse(Question):
         if self.answer_key is not None:
             rows.append(["AnswerKey", self.answer_key, *BLANK4])
         return rows
+
+
+class SectionHeader(WrittenResponse):
+    """Unscored dummy item that works as a visible section header."""
+
+    def __init__(self, title: str, body_html: str):
+        super().__init__(
+            title=f"Section ▸ {title}",
+            question_text=body_html,
+            points=0,
+            html_used=True,
+        )
 
 @dataclass
 class ShortAnswer(Question):

--- a/D2L_LMS_Quiz_and_Lesson_Builder/quiz_builder-Q4.py
+++ b/D2L_LMS_Quiz_and_Lesson_Builder/quiz_builder-Q4.py
@@ -11,12 +11,20 @@ from module_quiz_builder_to_csv import (
     QuestionBank,
     MultipleChoice,
     MCOption,
+    SectionHeader,
 )
 
 # ---------------------------------------------------------------------
 # Build the question bank
 # ---------------------------------------------------------------------
 bank = QuestionBank()
+
+bank.add(
+    SectionHeader(
+        "Lesson Outline",
+        "<h2>Lesson Outline</h2><p>This quiz covers sampling distributions and hypothesis testing.</p>",
+    )
+)
 
 # 1. Central Limit Theorem
 bank.add(

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This repository stores materials for the POL201 statistics course. The content i
 - **online-lessons/** – fully online lesson packages. This folder now holds the Week&nbsp;4 lessons in both Google Apps Script and HTML/JS forms.
 - **weekly-quizzes/** – LaTeX question sets, notes and logs used to generate Brightspace quiz CSVs.
 - **styles.css** – shared CSS used by some of the HTML lesson pages.
-- **scripts/** – Python utilities for quiz building and answer validation.
+- **scripts/** – Python utilities for quiz building and answer validation. The
+  quiz builder module includes a `SectionHeader` helper for adding dummy
+  section dividers in Brightspace CSV exports.
 - **instructions/** – assistant protocols referenced by the various `AGENTS.md` files.
 
 The `DESIGN_README.md` file outlines styling guidelines used when refreshing the lesson pages.

--- a/scripts/module_quiz_builder_to_csv.py
+++ b/scripts/module_quiz_builder_to_csv.py
@@ -14,6 +14,9 @@ question types programmatically, add them to a bank, and then export the
 whole set to a **CSV UTF‑8** file that is ready to import with the “Bulk
 question upload” tool (Add/Edit Questions → Import → Upload a File).
 
+It also includes a ``SectionHeader`` helper for inserting unscored dummy
+items that act as visible headers between groups of questions.
+
 It follows the exact column order/structure used in D2L’s sample
 `Sample_Question_Import_UTF8.csv` so the resulting file is accepted
 without manual tweaking.
@@ -134,6 +137,18 @@ class WrittenResponse(Question):
         if self.answer_key is not None:
             rows.append(["AnswerKey", self.answer_key, *BLANK4])
         return rows
+
+
+class SectionHeader(WrittenResponse):
+    """Unscored dummy item that works as a visible section header."""
+
+    def __init__(self, title: str, body_html: str):
+        super().__init__(
+            title=f"Section ▸ {title}",
+            question_text=body_html,
+            points=0,
+            html_used=True,
+        )
 
 @dataclass
 class ShortAnswer(Question):


### PR DESCRIPTION
## Summary
- add `SectionHeader` helper class for Brightspace CSV builder
- document the new helper in the module docstring and build docs
- show usage in quiz_builder-Q4 example
- mention helper in repo README

## Testing
- `python3 -m py_compile scripts/module_quiz_builder_to_csv.py D2L_LMS_Quiz_and_Lesson_Builder/module_quiz_builder_to_csv.py D2L_LMS_Quiz_and_Lesson_Builder/quiz_builder-Q4.py`

------
https://chatgpt.com/codex/tasks/task_e_685eeb2ae2788332af3de9fb08750afd