### PR TITLE
Improve lesson migration workflow

### DIFF
--- a/D2L_LMS_Quiz_and_Lesson_Builder/lesson_migration_protocol.md
+++ b/D2L_LMS_Quiz_and_Lesson_Builder/lesson_migration_protocol.md
@@ -5,7 +5,10 @@ This guide explains how to convert an interactive lesson stored in `spa_site/` i
 ## 1. Prepare the Environment
 1. Ensure Python 3.8+ is available.
 2. Place `module_quiz_builder_to_csv.py` in `D2L_LMS_Quiz_and_Lesson_Builder/` (already in the repo).
-3. Install any required packages (none beyond the standard library).
+3. Install dependencies:
+   ```bash
+   pip install beautifulsoup4
+   ```
 
 ## 2. Generate the CSV
 1. Navigate to the lesson folder. Example for Week 5:
@@ -14,17 +17,22 @@ This guide explains how to convert an interactive lesson stored in `spa_site/` i
    ```
 2. Run the helper script to convert `questions.json`:
    ```bash
-   python3 export_to_d2l_csv.py spa_site/questions.json lesson_week5.csv
+   python3 export_to_d2l_csv.py spa_site/questions.json lesson_week5.csv --verbose
    ```
-   The script cleans unsupported `<meta>`, `<style>` and `<title>` tags and exports a CSV containing `SectionHeader` rows for informational slides and `MultipleChoice` rows for questions.
+   The script now sanitises HTML by removing unsupported tags (e.g. `<meta>`, `<style>`, `<title>`, `<script>`, `<iframe>`), strips inline styles and event handlers, and logs warnings for missing fields. Use `--points` to set a non‑zero score per question if desired.
+3. Verify the output using the test helper:
+   ```bash
+   python3 scripts/test_lesson_csv.py spa_site/questions.json lesson_week5.csv
+   ```
+   This confirms the row count matches the lesson JSON.
 
 ## 3. Import into Brightspace
 1. In Brightspace, open the course quiz tool and choose **Import / Upload a File**.
 2. Select the generated `lesson_week5.csv` and complete the import.
-3. Each slide appears in order; questions have all options worth 0 points so the lesson functions as ungraded interactive content.
+3. Each slide appears in order; questions receive the point value specified with `--points` (default 0).
 
 ## 4. Customisation Notes
-- Edit `export_to_d2l_csv.py` if you need to change how slides are labelled or assign points.
+- The helper accepts `--points` and `--verbose`; editing the script should rarely be necessary.
 - The script uses the `QuestionBank` API documented in `module_quiz_builder_to_csv.py`.
 
 This process preserves the lesson text while adapting it to the Brightspace quiz format without any JavaScript.

--- a/online-lessons/pol201_lesson_week5_all_files/export_to_d2l_csv.py
+++ b/online-lessons/pol201_lesson_week5_all_files/export_to_d2l_csv.py
@@ -1,7 +1,11 @@
+"""Convert lesson JSON into a Brightspace compatible quiz CSV."""
+
 import json
-import re
+import logging
 from pathlib import Path
 import sys
+
+from typing import Any, List
 
 # Ensure the quiz builder module is importable when running this script
 ROOT_DIR = Path(__file__).resolve().parents[2]
@@ -14,26 +18,73 @@ from module_quiz_builder_to_csv import (
     SectionHeader,
 )
 
-def clean_html(text: str) -> str:
-    """Remove meta, title and style tags unsupported in Brightspace."""
-    text = re.sub(r"<meta[^>]*>", "", text, flags=re.IGNORECASE)
-    text = re.sub(r"<title[^>]*>.*?</title>", "", text, flags=re.IGNORECASE | re.DOTALL)
-    text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.IGNORECASE | re.DOTALL)
-    return text.strip()
+from bs4 import BeautifulSoup
 
-def convert(json_path: Path, csv_path: Path) -> None:
-    data = json.loads(json_path.read_text(encoding="utf-8"))
+ALLOWED_TAGS = {
+    "p",
+    "b",
+    "strong",
+    "em",
+    "i",
+    "ul",
+    "ol",
+    "li",
+    "br",
+    "span",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "img",
+    "div",
+}
+
+
+def clean_html(text: str) -> str:
+    """Sanitise lesson HTML removing unsupported tags and attributes."""
+    soup = BeautifulSoup(text, "html.parser")
+    for tag in soup.find_all(True):
+        if tag.name not in ALLOWED_TAGS:
+            tag.decompose()
+            continue
+        # Drop event handlers and inline styles
+        tag.attrs = {
+            k: v
+            for k, v in tag.attrs.items()
+            if not k.lower().startswith("on") and k.lower() not in {"style"}
+        }
+    return str(soup).strip()
+
+def convert(json_path: Path, csv_path: Path, *, points: int = 0) -> None:
+    """Convert `json_path` into a Brightspace CSV saved to `csv_path`."""
+    try:
+        data: List[dict[str, Any]] = json.loads(json_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logging.error("Invalid JSON: %s", exc)
+        raise SystemExit(1)
+
     bank = QuestionBank()
     slide_num = 1
     qnum = 1
-    for item in data:
-        html = clean_html(item.get("html", ""))
-        if item.get("choices"):
-            options = [MCOption(percent=0, text=c["text"], html_used=True) for c in item["choices"]]
+    for idx, item in enumerate(data, 1):
+        if "html" not in item:
+            logging.warning("Item %s missing 'html' key; skipping", idx)
+            continue
+        html = clean_html(str(item.get("html", "")))
+        choices = item.get("choices")
+        if isinstance(choices, list) and choices:
+            options = []
+            for c in choices:
+                if "text" not in c:
+                    logging.warning("Question %s has choice without text", idx)
+                    continue
+                options.append(MCOption(percent=0, text=c["text"], html_used=True))
             mc = MultipleChoice(
                 title=f"Question {qnum}",
                 question_text=html,
-                points=0,
+                points=points,
                 options=options,
                 html_used=True,
             )
@@ -42,8 +93,10 @@ def convert(json_path: Path, csv_path: Path) -> None:
         else:
             bank.add(SectionHeader(title=f"Slide {slide_num}", body_html=html))
             slide_num += 1
+
     bank.export_csv(csv_path)
-    print(f"\u2713 Wrote {csv_path}")
+    logging.info("Wrote %s", csv_path)
+    logging.info("Processed %d slides and %d questions", slide_num - 1, qnum - 1)
 
 if __name__ == "__main__":
     import argparse
@@ -51,5 +104,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert lesson JSON to D2L CSV")
     parser.add_argument("json", type=Path, help="Path to questions.json")
     parser.add_argument("csv", type=Path, help="Output CSV path")
+    parser.add_argument("--points", type=int, default=0, help="Point value for each question")
+    parser.add_argument("--verbose", action="store_true", help="Enable verbose logging")
     args = parser.parse_args()
-    convert(args.json, args.csv)
+
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING, format="%(levelname)s: %(message)s")
+
+    convert(args.json, args.csv, points=args.points)

--- a/scripts/test_lesson_csv.py
+++ b/scripts/test_lesson_csv.py
@@ -1,0 +1,42 @@
+"""Simple integration test for lesson CSV conversion."""
+
+import argparse
+import csv
+import json
+import importlib.util
+from pathlib import Path
+
+
+def load_module(path: Path):
+    spec = importlib.util.spec_from_file_location("converter", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def main(json_path: Path, csv_path: Path, script_path: Path) -> None:
+    module = load_module(script_path)
+    module.convert(json_path, csv_path)
+
+    expected = len(json.loads(json_path.read_text(encoding="utf-8")))
+    with csv_path.open(newline="", encoding="utf-8-sig") as f:
+        rows = list(csv.reader(f))
+    count = sum(1 for r in rows if r and r[0] == "NewQuestion")
+    if count != expected:
+        raise SystemExit(f"Row count mismatch: {count} != {expected}")
+    print("All tests passed")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("json", type=Path, help="Path to questions.json")
+    parser.add_argument("csv", type=Path, help="Output CSV path")
+    parser.add_argument(
+        "--script",
+        type=Path,
+        default=Path("online-lessons/pol201_lesson_week5_all_files/export_to_d2l_csv.py"),
+        help="Path to export_to_d2l_csv.py",
+    )
+    args = parser.parse_args()
+    main(args.json, args.csv, args.script)


### PR DESCRIPTION
## Summary
- enhance `export_to_d2l_csv.py` with robust HTML sanitisation, error checking, logging and CLI options
- document new workflow and test step in `lesson_migration_protocol.md`
- add `scripts/test_lesson_csv.py` integration test

## Testing
- `python3 -m py_compile online-lessons/pol201_lesson_week5_all_files/export_to_d2l_csv.py`
- `python3 -m py_compile scripts/test_lesson_csv.py`
- `python3 scripts/test_lesson_csv.py online-lessons/pol201_lesson_week5_all_files/spa_site/questions.json /tmp/test_week5.csv --script online-lessons/pol201_lesson_week5_all_files/export_to_d2l_csv.py`


------
https://chatgpt.com/codex/tasks/task_e_685ef02bb2ac8332b805a8fc51a30239